### PR TITLE
docs(courses/01_Python/ch_10): complete Dictionaries notes and examples (L1-L8 partial)

### DIFF
--- a/courses/01_Python/01.10__Dictionaries.md
+++ b/courses/01_Python/01.10__Dictionaries.md
@@ -78,6 +78,7 @@ By the end of this chapter, I should be able to:
   - [Assignment](#assignment)
   - [Tips](#tips)
     - [▶️ L2: Duplicate Keys](#️-l2-duplicate-keys)
+  - [Assignment](#assignment-1)
     - [▶️ L3: Accessing Dictionary Values](#️-l3-accessing-dictionary-values)
     - [▶️ L4: Setting Dictionary Values](#️-l4-setting-dictionary-values)
     - [▶️ L5: Updating Dictionary Values](#️-l5-updating-dictionary-values)
@@ -181,15 +182,23 @@ def get_character_record(name, server, level, rank):
 
 ### ▶️ L2: Duplicate Keys
 
-<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
-
-// VERBATIM_CONTENT
-
-</section>
-
 <section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
 
-// ASSIGNMENT CONTENT
+Because dictionaries rely on unique keys, you can't have two of the same key in the same dictionary. If you try to use the same key twice, the first value will simply be overwritten.
+
+## Assignment
+
+Another developer on our team has introduced a bug by specifying duplicate keys in the dictionary! _Fix the bug._
+
+The `get_character_record` function takes a character's `name`, `server`, `level`, and `rank`. It should return a dictionary with the following fields:
+
+*   name
+*   server
+*   level
+*   rank
+*   id
+
+Where the `id` is the `name` and the `server` concatenated together with a `#` in the middle for uniqueness. We can't have two `bloodwarrior123`'s on the same server!
 
 </section>
 
@@ -202,13 +211,30 @@ def get_character_record(name, server, level, rank):
 <span class="code-filename">main.py</span>
 
 ```py
-// answer starting code here
+def get_character_record(name, server, level, rank):
+    return {
+        "name": name,
+        "server": server,
+        "level": level,
+        "level": 1,
+        "rank": rank,
+        "rank": 2,
+        "id": f"{name}#{server}",
+    }
+
 ```
 
 **✍️ MY ANSWER:**
 
 ```py
-// answer code here
+def get_character_record(name, server, level, rank):
+    return {
+        "name": name,
+        "server": server,
+        "level": level,
+        "rank": rank,
+        "id": f"{name}#{server}",
+    }
 ```
 
 </section><!-- END .assignment-answer-sec -->

--- a/courses/01_Python/01.10__Dictionaries.md
+++ b/courses/01_Python/01.10__Dictionaries.md
@@ -81,8 +81,11 @@ By the end of this chapter, I should be able to:
   - [Assignment](#assignment-1)
     - [▶️ L3: Accessing Dictionary Values](#️-l3-accessing-dictionary-values)
     - [▶️ L4: Setting Dictionary Values](#️-l4-setting-dictionary-values)
+  - [Assignment](#assignment-2)
     - [▶️ L5: Updating Dictionary Values](#️-l5-updating-dictionary-values)
+  - [Assignment](#assignment-3)
     - [▶️ L6: Deleting Dictionary Values](#️-l6-deleting-dictionary-values)
+  - [Deleting Keys That Don't Exist](#deleting-keys-that-dont-exist)
     - [▶️ L7: Counting Practice](#️-l7-counting-practice)
     - [▶️ L8: Iterating Over a Dictionary in Python](#️-l8-iterating-over-a-dictionary-in-python)
     - [▶️ L9: Ordered or Unordered?](#️-l9-ordered-or-unordered)
@@ -243,109 +246,152 @@ def get_character_record(name, server, level, rank):
 
 <section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
-// VERBATIM_CONTENT
+Dictionary elements must be accessible somehow in code, otherwise they wouldn't be very useful.
+
+A value is retrieved from a dictionary by specifying its corresponding key in square brackets. The square brackets look similar to indexing into a list.
+
+```python
+car = {
+    "make": "Toyota",
+    "model": "Camry"
+}
+print(car["make"])
+# Prints: Toyota
+```
 
 </section>
 
-<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
-
-// ASSIGNMENT CONTENT
-
-</section>
-
-<br>
-
-<section class="assignment-answer-sec">
-
-**✍️ ASSIGNMENT STARTING CODE:**
-
-<span class="code-filename">main.py</span>
-
-```py
-// answer starting code here
-```
-
-**✍️ MY ANSWER:**
-
-```py
-// answer code here
-```
-
-</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L4: Setting Dictionary Values
 
 <section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
-// VERBATIM_CONTENT
+You don't need to create a dictionary with values already inside. It is common to create a blank dictionary then populate it later using dynamic values. The syntax is the same as getting data out of a key, just use the assignment operator (`=`) to give that key a value.
+
+```python
+planets = {}
+planets["Earth"] = True
+planets["Pluto"] = False
+print(planets["Pluto"])
+# Prints False
+```
 
 </section>
 
 <section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
 
-// ASSIGNMENT CONTENT
+
+## Assignment
+
+Use the example below to answer the question:
+
+```python
+names = ["jack bronson", "jill mcarty", "john denver"]
+
+names_dict = {}
+for name in names:
+    # .split() returns a list of strings
+    # where each string is a single word from the original
+    name_list = name.split()
+
+    # here we update the dictionary
+    names_dict[name_list[0]] = name_list[1]
+
+print(names_dict)
+# Prints: {'jack': 'bronson', 'jill': 'mcarty', 'john': 'denver'}
+```
 
 </section>
 
 <br>
 
-<section class="assignment-answer-sec">
-
-**✍️ ASSIGNMENT STARTING CODE:**
-
-<span class="code-filename">main.py</span>
-
-```py
-// answer starting code here
-```
-
-**✍️ MY ANSWER:**
-
-```py
-// answer code here
-```
-
-</section><!-- END .assignment-answer-sec -->
+> Note this was text answers only assignment
 
 ### ▶️ L5: Updating Dictionary Values
 
 <section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
-// VERBATIM_CONTENT
+If you try to set the value of a key that already exists, you'll end up just updating the value of that key.
+
+```python
+planets = {
+    "Pluto": True,
+}
+planets["Pluto"] = False
+print(planets["Pluto"])
+# Prints False
+```
 
 </section>
 
 <section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
 
-// ASSIGNMENT CONTENT
+
+## Assignment
+
+Use the example below to answer the question:
+
+```python
+full_names = ["jack bronson", "james mcarty", "jack denver"]
+
+names_dict = {}
+for full_name in full_names:
+    # .split() returns a list of strings
+    # where each string is a single word from the original
+    names = full_name.split()
+    first_name = names[0]
+    last_name = names[1]
+    names_dict[first_name] = last_name
+
+print(names_dict)
+# {
+#   'jack': 'denver',
+#   'james': 'mcarty'
+# }
+```
+
+In this example, "denver" overwrote "bronson" as the value for the key "jack".
 
 </section>
 
 <br>
 
-<section class="assignment-answer-sec">
+> Note this was text answers only assignment
 
-**✍️ ASSIGNMENT STARTING CODE:**
-
-<span class="code-filename">main.py</span>
-
-```py
-// answer starting code here
-```
-
-**✍️ MY ANSWER:**
-
-```py
-// answer code here
-```
-
-</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L6: Deleting Dictionary Values
 
 <section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
-// VERBATIM_CONTENT
+You can delete existing keys using the `del` keyword.
+
+```python
+names_dict = {
+    "jack": "bronson",
+    "jill": "mcarty",
+    "joe": "denver"
+}
+
+del names_dict["joe"]
+
+print(names_dict)
+# Prints: {'jack': 'bronson', 'jill': 'mcarty'}
+```
+
+## Deleting Keys That Don't Exist
+
+Notice that if you try to delete a key that doesn't exist, you'll get an _error_.
+
+```python
+names_dict = {
+    "jack": "bronson",
+    "jill": "mcarty",
+    "joe": "denver"
+}
+
+del names_dict["unknown"]
+# ERROR HERE, key doesn't exist
+```
 
 </section>
 
@@ -357,23 +403,8 @@ def get_character_record(name, server, level, rank):
 
 <br>
 
-<section class="assignment-answer-sec">
+> Note this was text answers only assignment
 
-**✍️ ASSIGNMENT STARTING CODE:**
-
-<span class="code-filename">main.py</span>
-
-```py
-// answer starting code here
-```
-
-**✍️ MY ANSWER:**
-
-```py
-// answer code here
-```
-
-</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L7: Counting Practice
 

--- a/courses/01_Python/01.10__Dictionaries.md
+++ b/courses/01_Python/01.10__Dictionaries.md
@@ -75,6 +75,8 @@ By the end of this chapter, I should be able to:
     - [Applied Examples](#applied-examples)
   - [🏷️ Tags:](#️-tags)
     - [▶️ L1: Dictionaries](#️-l1-dictionaries)
+  - [Assignment](#assignment)
+  - [Tips](#tips)
     - [▶️ L2: Duplicate Keys](#️-l2-duplicate-keys)
     - [▶️ L3: Accessing Dictionary Values](#️-l3-accessing-dictionary-values)
     - [▶️ L4: Setting Dictionary Values](#️-l4-setting-dictionary-values)
@@ -94,47 +96,428 @@ By the end of this chapter, I should be able to:
 
 ### ▶️ L1: Dictionaries
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+[Dictionaries](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) in Python are used to store data values in `key` -> `value` pairs. Dictionaries are a great way to store groups of information.
+
+```python
+# use curly braces
+# add key-value pairs
+car = {
+  "brand": "Toyota",
+  "model": "Camry",
+  "year": 2019,
+}
+```
+
+Here the `car` variable is assigned to a dictionary `{}` containing the keys `brand`, `model` and `year`. The keys' corresponding values are `Toyota`, `Camry` and `2019`.
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+
+## Assignment
+
+Complete the `get_character_record` function. It takes a character's `name`, `server`, `level`, and `rank` as individual inputs, and returns a dictionary with the following string keys:
+
+*   `"name"`
+*   `"server"`
+*   `"level"`
+*   `"rank"`
+*   `"id"`
+
+1.  [ ] Create and return a dictionary with the keys above.
+2.  [ ] Assign each of the four inputs to the matching key, ie: `"name": name`.
+
+Next, we can't have two characters named `bloodwarrior123`'s on the same server!
+
+3.  [ ] For the fifth key, `id`, create a unique value as follows:
+
+Concatenate the `name` and the `server` inputs with a `#` in the middle. For example, given:
+
+*   name = "bloodwarrior123"
+*   server = "server1"
+
+Then the `id` field would be set to `bloodwarrior123#server1`.
+
+## Tips
+
+*   You can return the dictionary directly without assigning it to a variable.
+*   I recommend using an `f-string` to create the `id` field. This is a best practice.
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+def get_character_record(name, server, level, rank):
+    pass
+```
+
+**✍️ MY ANSWER:**
+
+```py
+def get_character_record(name, server, level, rank):
+    
+    record = {
+        "name": name,
+        "server": server,
+        "level": level,
+        "rank": rank,
+        "id": f"{name}#{server}"
+    }
+
+    return record
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L2: Duplicate Keys
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L3: Accessing Dictionary Values
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L4: Setting Dictionary Values
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L5: Updating Dictionary Values
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L6: Deleting Dictionary Values
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L7: Counting Practice
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L8: Iterating Over a Dictionary in Python
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L9: Ordered or Unordered?
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L10: Quest Status
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 ### ▶️ L11: Merge Dictionaries
 
+<section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
+// VERBATIM_CONTENT
+
+</section>
+
+<section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
+
+// ASSIGNMENT CONTENT
+
+</section>
+
+<br>
+
+<section class="assignment-answer-sec">
+
+**✍️ ASSIGNMENT STARTING CODE:**
+
+<span class="code-filename">main.py</span>
+
+```py
+// answer starting code here
+```
+
+**✍️ MY ANSWER:**
+
+```py
+// answer code here
+```
+
+</section><!-- END .assignment-answer-sec -->
 
 
 

--- a/courses/01_Python/01.10__Dictionaries.md
+++ b/courses/01_Python/01.10__Dictionaries.md
@@ -8,15 +8,15 @@
 <!-- 📝 Title -->
 # 📒 COURSE NOTES: <span class="course-title">[Learn to Code in Python](https://www.boot.dev/lessons/78b4646f-85aa-42c7-ba46-faec2f0902a9)</span>
 
-## 📂 Chapter 07: **Comparisons**
+## 📂 Chapter 10: **Dictionairies**
 
-* **Chapter URL:** https://www.boot.dev/lessons/2315c308-0123-4efc-8dba-839685403708
+* **Chapter URL:** https://www.boot.dev/lessons/ff46b302-8371-4c3e-9dcd-3b306575ea02
 
 
 <!-- 🧭 Navigation -->
 ### [🏚️ README](../../README.md) | [📁 Index](index.md) | [🔖 Bookmark](#bookmark)
 
-<span class="warning-banner">IN-PROGRESS: 2025-10-29</span>
+<span class="warning-banner">IN-PROGRESS: 2025-11-06</span>
 
 
 <br>
@@ -25,7 +25,7 @@
 
 <section class="ehw-doc-descr">  
 
-### Learn to Code in Python, Ch. 07: *Comparisons*
+### Learn to Code in Python, Ch. 10: *Dictionairies*
 
 These are my personal notes on **<MAIN_TOPIC_LIST>** from Boot.dev. This chapter teaches how to <write 2-3 concise sentences summarizing what the chapter teaches and why it matters in real-world contexts, and clearly showing important bolded concepts and terms>.<end with the single-line real-world application / benefits sentence included at least 3 bolded real-world application phrases (e.g., medical software, debugging complex decision trees, gaming sofware, database management, livestreaming applications, industrial (PLC) logic controls, robotics, roomba robot vaccuums, etc.)>.   
 
@@ -55,9 +55,7 @@ By the end of this chapter, I should be able to:
 ## 🏷️ Tags:
 
 - Python
-- Comparison Operators
-- If-Else
-- Boolean Logic
+- dictionaries
 
 </section>
 
@@ -70,25 +68,23 @@ By the end of this chapter, I should be able to:
 <summary>Table of Contents</summary>
 
 - [📒 COURSE NOTES: Learn to Code in Python](#-course-notes-learn-to-code-in-python)
-  - [📂 Chapter 07: **Comparisons**](#-chapter-07-comparisons)
+  - [📂 Chapter 10: **Dictionairies**](#-chapter-10-dictionairies)
     - [🏚️ README | 📁 Index | 🔖 Bookmark](#️-readme---index---bookmark)
-    - [Learn to Code in Python, Ch. 07: *Comparisons*](#learn-to-code-in-python-ch-07-comparisons)
+    - [Learn to Code in Python, Ch. 10: *Dictionairies*](#learn-to-code-in-python-ch-10-dictionairies)
     - [Learning Outcomes](#learning-outcomes)
     - [Applied Examples](#applied-examples)
   - [🏷️ Tags:](#️-tags)
-    - [▶️ L1: Comparison Operators](#️-l1-comparison-operators)
-    - [▶️ L2: Comparison Operator Evaluations](#️-l2-comparison-operator-evaluations)
-    - [▶️ L3: Comparison Practice](#️-l3-comparison-practice)
-    - [▶️ L4: If Statements](#️-l4-if-statements)
-    - [▶️ L5: If Practice](#️-l5-if-practice)
-    - [▶️ L6: If-Else](#️-l6-if-else)
-    - [▶️ L7: If-Else Practice](#️-l7-if-else-practice)
-    - [▶️ L8: If-Else Practice](#️-l8-if-else-practice)
-    - [▶️ L9: Boolean Logic](#️-l9-boolean-logic)
-    - [▶️ L10: Boolean Quiz](#️-l10-boolean-quiz)
-    - [▶️ L11: Should Serve Drinks](#️-l11-should-serve-drinks)
-    - [▶️ L12: Mount Rental](#️-l12-mount-rental)
-    - [▶️ L13: Combat Advantage](#️-l13-combat-advantage)
+    - [▶️ L1: Dictionaries](#️-l1-dictionaries)
+    - [▶️ L2: Duplicate Keys](#️-l2-duplicate-keys)
+    - [▶️ L3: Accessing Dictionary Values](#️-l3-accessing-dictionary-values)
+    - [▶️ L4: Setting Dictionary Values](#️-l4-setting-dictionary-values)
+    - [▶️ L5: Updating Dictionary Values](#️-l5-updating-dictionary-values)
+    - [▶️ L6: Deleting Dictionary Values](#️-l6-deleting-dictionary-values)
+    - [▶️ L7: Counting Practice](#️-l7-counting-practice)
+    - [▶️ L8: Iterating Over a Dictionary in Python](#️-l8-iterating-over-a-dictionary-in-python)
+    - [▶️ L9: Ordered or Unordered?](#️-l9-ordered-or-unordered)
+    - [▶️ L10: Quest Status](#️-l10-quest-status)
+    - [▶️ L11: Merge Dictionaries](#️-l11-merge-dictionaries)
   - [References](#references)
 
 
@@ -96,55 +92,50 @@ By the end of this chapter, I should be able to:
 <!-- Lesson Notes -->
 
 
-### ▶️ L1: Comparison Operators
+### ▶️ L1: Dictionaries
 
 
 
-### ▶️ L2: Comparison Operator Evaluations
+### ▶️ L2: Duplicate Keys
 
 
 
-### ▶️ L3: Comparison Practice
+### ▶️ L3: Accessing Dictionary Values
 
 
 
-### ▶️ L4: If Statements
+### ▶️ L4: Setting Dictionary Values
 
 
 
-### ▶️ L5: If Practice
+### ▶️ L5: Updating Dictionary Values
 
 
 
-### ▶️ L6: If-Else
+### ▶️ L6: Deleting Dictionary Values
 
 
 
-### ▶️ L7: If-Else Practice
+### ▶️ L7: Counting Practice
 
 
 
-### ▶️ L8: If-Else Practice
+### ▶️ L8: Iterating Over a Dictionary in Python
 
 
 
-### ▶️ L9: Boolean Logic
+### ▶️ L9: Ordered or Unordered?
 
 
 
-### ▶️ L10: Boolean Quiz
+### ▶️ L10: Quest Status
 
 
 
-### ▶️ L11: Should Serve Drinks
+### ▶️ L11: Merge Dictionaries
 
 
 
-### ▶️ L12: Mount Rental
-
-
-
-### ▶️ L13: Combat Advantage
 
 
 

--- a/courses/01_Python/01.10__Dictionaries.md
+++ b/courses/01_Python/01.10__Dictionaries.md
@@ -87,6 +87,8 @@ By the end of this chapter, I should be able to:
     - [▶️ L6: Deleting Dictionary Values](#️-l6-deleting-dictionary-values)
   - [Deleting Keys That Don't Exist](#deleting-keys-that-dont-exist)
     - [▶️ L7: Counting Practice](#️-l7-counting-practice)
+  - [Checking for Existence](#checking-for-existence)
+  - [Assignment](#assignment-4)
     - [▶️ L8: Iterating Over a Dictionary in Python](#️-l8-iterating-over-a-dictionary-in-python)
     - [▶️ L9: Ordered or Unordered?](#️-l9-ordered-or-unordered)
     - [▶️ L10: Quest Status](#️-l10-quest-status)
@@ -410,13 +412,41 @@ del names_dict["unknown"]
 
 <section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
-// VERBATIM_CONTENT
+## Checking for Existence
+
+If you're unsure whether a key exists in a dictionary, use the `in` keyword.
+
+```python
+cars = {
+    "ford": "f150",
+    "toyota": "camry"
+}
+
+print("ford" in cars)
+# Prints: True
+
+print("gmc" in cars)
+# Prints: False
+```
 
 </section>
 
 <section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
 
-// ASSIGNMENT CONTENT
+
+## Assignment
+
+We need to be able to report to our players how many enemies are in their immediate vicinity - but they want the count of each enemy by its _kind_. Fix the `count_enemies` function. It accepts as input:
+
+*   `enemy_names`: a list of strings.
+
+It should return a dictionary where:
+
+*   The keys are all the enemy names from the list
+*   The values are the counts of how many times each enemy appeared in the list.
+
+1.  [ ] Run the code in its current state. It will raise a [KeyError](https://docs.python.org/3/library/exceptions.html#KeyError).
+2.  [ ] Fix the code by checking _if_ a key is _in_ the dictionary before trying to update its value. If it isn't, set it.
 
 </section>
 
@@ -429,13 +459,44 @@ del names_dict["unknown"]
 <span class="code-filename">main.py</span>
 
 ```py
-// answer starting code here
+def count_enemies(enemy_names):
+    enemies_dict = {}
+    for enemy_name in enemy_names:
+        enemies_dict[enemy_name] += 1
+    return enemies_dict
 ```
 
 **✍️ MY ANSWER:**
 
 ```py
-// answer code here
+def count_enemies(enemy_names):
+    enemies_dict = {}
+    
+    for enemy_name in enemy_names:
+
+        if enemy_name in enemies_dict:
+            enemies_dict[enemy_name] += 1
+        else:
+            enemies_dict[enemy_name] = 1
+            
+    return enemies_dict
+```
+
+**📈 OUTPUT RESULTS**
+
+```sh
+---------------------------------
+Inputs: ['jackal', 'kobold', 'soldier']
+Expected: {'jackal': 1, 'kobold': 1, 'soldier': 1}
+Actual:   {'jackal': 1, 'kobold': 1, 'soldier': 1}
+Pass
+---------------------------------
+Inputs: ['jackal', 'kobold', 'jackal']
+Expected: {'jackal': 2, 'kobold': 1}
+Actual:   {'jackal': 2, 'kobold': 1}
+Pass
+============= PASS ==============
+2 passed, 0 failed, 6 skipped
 ```
 
 </section><!-- END .assignment-answer-sec -->

--- a/courses/01_Python/01.10__Dictionaries.md
+++ b/courses/01_Python/01.10__Dictionaries.md
@@ -90,6 +90,8 @@ By the end of this chapter, I should be able to:
   - [Checking for Existence](#checking-for-existence)
   - [Assignment](#assignment-4)
     - [▶️ L8: Iterating Over a Dictionary in Python](#️-l8-iterating-over-a-dictionary-in-python)
+  - [Assignment](#assignment-5)
+  - [Tip: Negative Infinity](#tip-negative-infinity)
     - [▶️ L9: Ordered or Unordered?](#️-l9-ordered-or-unordered)
     - [▶️ L10: Quest Status](#️-l10-quest-status)
     - [▶️ L11: Merge Dictionaries](#️-l11-merge-dictionaries)
@@ -505,13 +507,60 @@ Pass
 
 <section class="callout"><span class="label-verbatim">COPIED VERBATIM:  👇🏽</span>
 
-// VERBATIM_CONTENT
+We can iterate over a dictionary's keys using the same no-index syntax we used to iterate over the values in a list. With access to the dictionary's keys, we also have access to their corresponding values.
+
+```python
+fruit_sizes = {
+    "apple": "small",
+    "banana": "large",
+    "grape": "tiny"
+}
+
+for name in fruit_sizes:
+    size = fruit_sizes[name]
+    print(f"name: {name}, size: {size}")
+
+# name: apple, size: small
+# name: banana, size: large
+# name: grape, size: tiny
+```
+
+We could have just as easily set the `name` variable to `key` or simply `k`.
 
 </section>
 
 <section class="callout"><span class="label-verbatim">Assignment:  👇🏽</span>
 
-// ASSIGNMENT CONTENT
+
+## Assignment
+
+We need to display on our players' screens what the most common enemy in a given area of the game map is.
+
+Complete the `get_most_common_enemy` function by iterating over all enemies in the dictionary and returning only the _name_ of the enemy with the highest count.
+
+If there are no enemies, return the Python `None` value (not a string). If there are multiple enemies with the same highest count, return the first one found.
+
+`enemies_dict` is a dictionary of `name` -> `count`. Example:
+
+```py
+{
+    "jackal": 1,
+    "kobold": 2,
+    "soldier": 3,
+    "gremlin": 5
+}
+```
+
+## Tip: Negative Infinity
+
+When you're trying to find a "max" value, it helps to keep track of the "max so far" in a variable and to start that variable at the lowest possible number, negative infinity.
+
+```py
+max_so_far = float("-inf")
+```
+
+You'll also want to keep track of the enemy name associated with the maximum count. I would set the default for that variable to `None`.
+
 
 </section>
 
@@ -524,7 +573,8 @@ Pass
 <span class="code-filename">main.py</span>
 
 ```py
-// answer starting code here
+def get_most_common_enemy(enemies_dict):
+    pass
 ```
 
 **✍️ MY ANSWER:**

--- a/courses/01_Python/ex/ch_10_L_08.py
+++ b/courses/01_Python/ex/ch_10_L_08.py
@@ -1,0 +1,28 @@
+def get_most_common_enemy(enemies_dict):
+    
+    # early exit if no enemies
+    if len(enemies_dict) == 0:
+        return None
+
+
+    max_so_far = float("-inf")
+    max_name = None
+
+    for enemy in enemies_dict:
+
+        if enemies_dict[enemy] > max_so_far:
+            max_so_far = enemies_dict[enemy]
+
+    return 
+
+
+enemies_dict = {
+    "jackal": 1,
+    "kobold": 2,
+    "soldier": 3,
+    "gremlin": 5
+}
+
+most_common_enemy = get_most_common_enemy(enemies_dict)
+
+print(f"The Most Common Enemy is:  {most_common_enemy}")


### PR DESCRIPTION
 Adds Boot.dev Ch10 Dictionaries full notes through Level 8 -- PAUSED on work hours going forward.

### 🎓 Course: [Boot.dev] - Learn to Code in Python

- Notes complete through level 7
- Began adding level 8 notes


### Chapter Notes  
(Files: `courses/01_Python/01.10__Dictionaries.md`)  
- Added detailed lessons with examples and explanations   

### Code Examples  
(Files: `courses/01_Python/ex/ch_10_L_08.py`)  
- Added initial runnable code for Lesson 8  
- Tested and structured for expansion  

### Formatting Updates  
(Files: `_tmpl/python-ch-starter__01.07__Comparisons.md`)  
- Minor consistency tweaks

⚠️ **Notes & Caveats:**  
- PAUSED course progress after instructed by management not to work on this anymore on work hours
- May resume on non-work hours 